### PR TITLE
PrintingWindow: missing cmath for std::sqrt().

### DIFF
--- a/application/PrintingWindow.cpp
+++ b/application/PrintingWindow.cpp
@@ -9,6 +9,7 @@
 #include "PrintingWindow.h"
 
 #include <algorithm>
+#include <cmath>
 #include <memory>
 
 #include <Application.h>


### PR DESCRIPTION
to build on x86_64.