### PR TITLE
Increase the zoom when opening a file

### DIFF
--- a/application/DocumentView.cpp
+++ b/application/DocumentView.cpp
@@ -78,6 +78,7 @@ DocumentView::FileChanged(const BString& file, BString const& fileType,
 	BString& password)
 {
 	fBasicDocumentView->SetFile(file, fileType, password);
+	Window()->PostMessage(MSG_FIT_PAGE_HEIGHT);
 }
 
 


### PR DESCRIPTION
I basically made the `FileChanged` method send a `MSG_FIT_PAGE_HEIGHT` message which seems to set the zoom to an optimal and readable level, at least in my opinion. Let me know if I should approach this differently or if I should change anything.

Fixes #8