### PR TITLE
Now limits window size

### DIFF
--- a/application/MainWindow.cpp
+++ b/application/MainWindow.cpp
@@ -99,6 +99,7 @@ MainWindow::MainWindow(void)
 	fCardLayout->AddItem(fDocumentLayout);
 	fCardLayout->SetVisibleItem(fIntroLayout);
 	_LoadSettings();
+	ResizeTo(1200, 600); ///Show 3 documents and minimize empty space
 	Show();
 }
 
@@ -158,6 +159,7 @@ MainWindow::MessageReceived(BMessage* message)
    			fCardLayout->SetVisibleItem((BLayoutItem*)fIntroLayout);
    			fImageSpinner->MakeFocus(true);
    			SetTitle("DocumentViewer");
+			ResizeTo(1200, 600); //Show 3 documents and minimize empty space
 			//be_app->PostMessage(B_QUIT_REQUESTED);
 			break;
         }


### PR DESCRIPTION
Fixes #6 
Now, instead of taking all available space, the application opens to a more manageable size.
The size chosen is chosen because with it, in the document select screen (start-up screen), 3 documents are displayed and there is no unnecessary vertical empty space. Looks more professional now, and is easier to use.