### PR TITLE
Start updating for mupdf 1.19

### DIFF
--- a/application/PDFEngine.cpp
+++ b/application/PDFEngine.cpp
@@ -46,24 +46,24 @@ private:
 
 
 PDFEngine::PDFEngine(BString fileName, BString& password)
-    :
-    fFileName(fileName),
-    fPassword(password)
+	:
+	fFileName(fileName),
+	fPassword(password)
 {
 	fHighlightUnderText = true;
-    fDocument = nullptr;
-    fz_var(fDocument);
+	fDocument = nullptr;
+	fz_var(fDocument);
 
 	fz_lock_impl* locks = new fz_lock_impl;
 	fContext = fz_new_context(nullptr, &locks->context, FZ_STORE_DEFAULT);
 	fz_register_document_handlers(fContext);
-    // why bgr instead of rgb?
-    fColorSpace = fz_device_bgr(fContext);
+	// why bgr instead of rgb?
+	fColorSpace = fz_device_bgr(fContext);
 
-    if (!fContext) {
-    	!out << "cannot init context" << endl;
-    	exit(1);
-    }
+	if (!fContext) {
+		!out << "cannot init context" << endl;
+		exit(1);
+	}
 
 	fz_try(fContext) {
 		fDocument = fz_open_document(fContext, fileName.String());
@@ -86,10 +86,10 @@ PDFEngine::PDFEngine(BString fileName, BString& password)
 			}
 		} else {
 			int okay = fz_authenticate_password(fContext, fDocument,
-            	const_cast<char*>(password.String()));
+				const_cast<char*>(password.String()));
 
-          	if (!okay)
-          		throw "wrong password";
+		  	if (!okay)
+		  		throw "wrong password";
 		}
 	}
 
@@ -144,8 +144,6 @@ PDFEngine::WriteOutline(BOutlineListView* list)
 			if (outline->down)
 				OutlineToList(outline->down,list, item, level + 1);
 
-	//		((OutlineListView*)list)->ReverseOrder(super);
-
 			outline = outline->next;
 		}
 	};
@@ -172,17 +170,15 @@ PDFEngine::_FindString(BString const& name, int const& pageNumber)
 	vector<BRect>	rectVec;
 
 	bool needWholeWord = false;
-    if (GHasFlag(fSearchFlag, SEARCH_WHOLE_WORD))
-    	needWholeWord = true;
+	if (GHasFlag(fSearchFlag, SEARCH_WHOLE_WORD))
+		needWholeWord = true;
 
-    bool needMatchCase = false;
-    if (GHasFlag(fSearchFlag, SEARCH_MATCH_CASE))
-    	needMatchCase = true;
+	bool needMatchCase = false;
+	if (GHasFlag(fSearchFlag, SEARCH_MATCH_CASE))
+		needMatchCase = true;
 
-    fz_page* page = nullptr;
-    page = fz_load_page(fContext, fDocument, pageNumber);
-
-    // fz_text_sheet* sheet = fz_new_text_sheet(fContext);
+	fz_page* page = nullptr;
+	page = fz_load_page(fContext, fDocument, pageNumber);
 
 	fz_device* dev = nullptr;
 	fz_var(dev);
@@ -196,6 +192,7 @@ PDFEngine::_FindString(BString const& name, int const& pageNumber)
 
 		// Load the text from the page
 		fz_run_page(fContext, page, dev, fz_identity, NULL);
+		fz_close_device(fContext, dev);
 		fz_drop_device(fContext, dev);
 		dev = nullptr;
 
@@ -238,10 +235,9 @@ PDFEngine::_FindString(BString const& name, int const& pageNumber)
 
 
 	} fz_catch(fContext) {
-        fz_close_device(fRenderContext, dev);
+		fz_close_device(fContext, dev);
 		fz_drop_device(fContext, dev);
 		fz_drop_stext_page(fContext, text);
-		// fz_drop_text_sheet(fContext, sheet);
 		fz_rethrow(fContext);
 	}
 
@@ -252,9 +248,9 @@ PDFEngine::_FindString(BString const& name, int const& pageNumber)
 BString
 PDFEngine::GetProperty(BString name)
 {
-    BString property;
-    /*
-    fz_obj* info = fz_dict_gets(fDocument->trailer, "Info");
+	BString property;
+	/*
+	fz_obj* info = fz_dict_gets(fDocument->trailer, "Info");
 
 	if (info) {
 		fz_obj* obj = fz_dict_gets(info, const_cast<char*>(name.String()));
@@ -263,14 +259,14 @@ PDFEngine::GetProperty(BString name)
 	}
 	*/
 
-    return property;
+	return property;
 }
 
 
 BString
 PDFEngine::FileName(void) const
 {
-    return fFileName;
+	return fFileName;
 }
 
 
@@ -279,7 +275,7 @@ PDFEngine::RenderBitmap(int const& pageNumber,
 	int const& width, int const& height, int const& rotation)
 {
 	if (pageNumber < 0 || pageNumber >= fPages) {
-    	return unique_ptr<BBitmap>(nullptr);
+		return unique_ptr<BBitmap>(nullptr);
 	}
 
 	fz_page *page;
@@ -291,34 +287,34 @@ PDFEngine::RenderBitmap(int const& pageNumber,
 
 	pthread_mutex_lock(&fRendermutex);
 
-    bool stop = false;	// variable for avoiding return in fz_catch
+	bool stop = false;	// variable for avoiding return in fz_catch
 	fz_try(fRenderContext) {
 		page = fz_load_page(fRenderContext, fDocument, pageNumber);
 	} fz_catch(fRenderContext) {
 		pthread_mutex_unlock(&fRendermutex);
-    	stop = true;
-    }
+		stop = true;
+	}
 
-    if (stop)
-    	return std::make_unique<BBitmap>(BRect(0, 0, width, height), B_RGBA32);
+	if (stop)
+		return std::make_unique<BBitmap>(BRect(0, 0, width, height), B_RGBA32);
 
 	fz_try(fRenderContext) {
-		list = fz_new_display_list(fRenderContext, fz_bound_page(fContext, page));
+		list = fz_new_display_list(fRenderContext, fz_empty_rect);
 		dev = fz_new_list_device(fRenderContext, list);
 		fz_run_page(fRenderContext, page, dev, fz_identity, nullptr);
 	} fz_catch(fRenderContext) {
-        fz_close_device(fRenderContext, dev);
+		fz_close_device(fRenderContext, dev);
 		fz_drop_device(fRenderContext, dev);
 		fz_drop_display_list(fRenderContext, list);
 		fz_drop_page(fRenderContext, page);
 		pthread_mutex_unlock(&fRendermutex);
-    	stop = true;
+		stop = true;
 	}
 
 	if (stop)
-    	return std::make_unique<BBitmap>(BRect(0, 0, width, height), B_RGBA32);
+		return std::make_unique<BBitmap>(BRect(0, 0, width, height), B_RGBA32);
 
-    fz_close_device(fRenderContext, dev);
+	fz_close_device(fRenderContext, dev);
 	fz_drop_device(fRenderContext, dev);
 	dev = nullptr;
 
@@ -335,50 +331,47 @@ PDFEngine::RenderBitmap(int const& pageNumber,
 		zoomFactor = width / (bounds.x1 - bounds.x0);
 	}
 
-    fz_matrix ctm = fz_rotate(fRotation);
-  	fz_pre_scale(ctm, zoomFactor, zoomFactor);
-    fz_irect pageBox = fz_round_rect(fz_transform_rect(bounds, ctm));
-    fz_separations *seps = fz_page_separations(fContext, page);
+	fz_matrix ctm = fz_pre_scale(fz_rotate(fRotation), zoomFactor, zoomFactor);
+	fz_irect pageBox = fz_round_rect(fz_transform_rect(bounds, ctm));
+	fz_separations *seps = fz_page_separations(fContext, page);
 
 	fz_try(fRenderContext) {
 		image = fz_new_pixmap_with_bbox(fRenderContext, fColorSpace, pageBox, seps, 1);
 
-    	//save alpha
-		//fz_clear_pixmap(fRenderContext, image);
 		fz_clear_pixmap_with_value(fRenderContext, image, 255);
 		dev = fz_new_draw_device(fRenderContext, fz_identity, image);
-    	if (list)
+		if (list)
 			fz_run_display_list(fRenderContext, list, dev, ctm, bounds, nullptr);
    		 else
 			fz_run_page(fRenderContext, page, dev, ctm, nullptr);
-            
-        fz_close_device(fRenderContext, dev);
+			
+		fz_close_device(fRenderContext, dev);
 		fz_drop_device(fRenderContext, dev);
-    	dev = nullptr;
+		dev = nullptr;
 	} fz_catch(fRenderContext) {
-        fz_close_device(fRenderContext, dev);
+		fz_close_device(fRenderContext, dev);
 		fz_drop_device(fRenderContext, dev);
 		fz_drop_pixmap(fRenderContext, image);
 		fz_drop_display_list(fRenderContext, list);
 		fz_drop_page(fRenderContext, page);
 		pthread_mutex_unlock(&fRendermutex);
-    	stop = true;
+		stop = true;
 	}
 
 	if (stop)
-    	return std::make_unique<BBitmap>(BRect(0, 0, width, height), B_RGBA32);
+		return std::make_unique<BBitmap>(BRect(0, 0, width, height), B_RGBA32);
 
 	fz_flush_warnings(fRenderContext);
 
-    int imageWidth = pageBox.x1 - pageBox.x0;
-    int imageHeight = pageBox.y1 - pageBox.y0;
+	int imageWidth = pageBox.x1 - pageBox.x0;
+	int imageHeight = pageBox.y1 - pageBox.y0;
 
 
-    BBitmap* bitmap = new BBitmap(BRect(0, 0, imageWidth - 1, imageHeight - 1), B_RGBA32);
+	BBitmap* bitmap = new BBitmap(BRect(0, 0, imageWidth - 1, imageHeight - 1), B_RGBA32);
 	bitmap->SetBits(fz_pixmap_samples(fRenderContext, image),
 		imageWidth * imageHeight * fz_pixmap_components(fRenderContext, image), 0, B_RGBA32);
-    
-    fz_close_device(fRenderContext, dev);
+	
+	fz_close_device(fRenderContext, dev);
 	fz_drop_device(fRenderContext, dev);
 	fz_drop_pixmap(fRenderContext, image);
 	fz_drop_display_list(fRenderContext, list);
@@ -395,5 +388,5 @@ PDFEngine::_RenderBitmap(int const& pageNumber)
 	unique_ptr<BBitmap> bitmap = RenderBitmap(pageNumber, fDefaultRect.Width(),
 		fDefaultRect.Height(), 0);
 
-    return std::pair<BBitmap*, bool>(bitmap.release(), false);
+	return std::pair<BBitmap*, bool>(bitmap.release(), false);
 }

--- a/application/PDFEngine.cpp
+++ b/application/PDFEngine.cpp
@@ -249,15 +249,6 @@ BString
 PDFEngine::GetProperty(BString name)
 {
 	BString property;
-	/*
-	fz_obj* info = fz_dict_gets(fDocument->trailer, "Info");
-
-	if (info) {
-		fz_obj* obj = fz_dict_gets(info, const_cast<char*>(name.String()));
-		if (obj)
-			property = pdf_to_utf8(obj);
-	}
-	*/
 
 	return property;
 }

--- a/application/PDFEngine.h
+++ b/application/PDFEngine.h
@@ -57,7 +57,7 @@ private:
     BString                 fFileName;
     BString               	fPassword;
     
-	pthread_mutex_t			fRendermutex;
+	pthread_mutex_t			fRendermutex = PTHREAD_MUTEX_INITIALIZER;
 
     Debug             		out;
 };


### PR DESCRIPTION
As part of my project to get the latest version of MuPDF into HaikuPorts https://github.com/haikuports/haikuports/pull/6823 I have updated applications that depend on it https://github.com/threedeyes/PDFTranslator/pull/5 leaving only this one to update as far as I know. 

I have updated all the function calls to suit the new version of the library, but I've run into issues with the multi-threaded loading where for some files it seems one of the threads doesn't release `fRendermutex` and the program hangs. EDIT - think I fixed this by initialising the mutex. Not sure if this is the right thing to do (I haven't worked with threads before) 

There are other crashes too and functionality that doesn't work. 

Clearly I have missed something - I'm looking for advice on how to debug something like this and a second pair of eyes on my code. Any help would be much appreciated.

I will of course carry on working on this when I get a chance.

The code from this pull request doesn't work properly so isn't ready to merge!