### PR TITLE
Fix compiler warnings

### DIFF
--- a/application/BaseEngine.cpp
+++ b/application/BaseEngine.cpp
@@ -364,7 +364,7 @@ BaseEngine::_TextSearchThread(void* arg)
 
 		auto t = engine->_FindString(name, page);
 
-		for (int i = 0; i < get<0>(t).size(); ++i) {
+		for (uint32 i = 0; i < get<0>(t).size(); ++i) {
 			BMessage msg(MSG_SEARCH_RESULT);
 			msg.AddInt32("page", page);
 			msg.AddString("context", move(get<0>(t)[i]));

--- a/application/BaseEngine.cpp
+++ b/application/BaseEngine.cpp
@@ -18,6 +18,7 @@ pthread_mutex_t	BaseEngine::gTextSearchStopMutex = PTHREAD_MUTEX_INITIALIZER;
 
 BaseEngine::BaseEngine(void)
 	:
+	fStopThread(false),
   	fZoomFactor(1),
   	fPages(0),
  	fRotation(0),
@@ -26,9 +27,8 @@ BaseEngine::BaseEngine(void)
  	fCurrentPageNo(0),
  	fSearchFlag(0),
  	fDefaultRect(0, 0, 300, 500),
-  	fStopThread(false),
-  	fStopTextSearchThread(false),
-  	fHighlightUnderText(false)
+	fHighlightUnderText(false),
+	fStopTextSearchThread(false)
 {
 	fTextSearchThread = nullptr;
 	fDrawingThread = nullptr;

--- a/application/BaseEngine.h
+++ b/application/BaseEngine.h
@@ -30,10 +30,10 @@ class BaseEngine
 public:
         					BaseEngine(void);
     virtual 				~BaseEngine();
-    
+
     void					Start(void);
     void					Stop(void);
-    
+
     void					StopTextSearch(void);
 
     // the name of the file this engine handles
@@ -52,21 +52,21 @@ public:
 
     // the angle in degrees the given page is rotated natively (usually 0 deg)
     virtual int const&		PageRotation(int pageNumber);
-    
-    virtual std::unique_ptr<BBitmap> RenderBitmap(int const& pageNumber,int const& width,
-    										int const& height, int const& rotation = 0) = 0;
+
+    virtual std::unique_ptr<BBitmap> RenderBitmap(int const& pageNumber,uint32 const& width,
+    										uint32 const& height, int const& rotation = 0) = 0;
 
     virtual BBitmap* 		Page(int pageNumber);
-    
+
     // access to various document properties (such as Author, Title, etc.)
     virtual BString 		GetProperty(BString name) { return BString(""); }
-	
+
 	virtual BString 		GetPageLabel(int pageNumber);
-    
+
     // reverts GetPageLabel by returning the first page number
     // having the given label
     virtual int 			GetPageByLabel(BString label);
-    
+
     // returns a string to remember when the user wants to save
     // a document's password (don't implement for document types
     // that don't support password protection)
@@ -74,58 +74,58 @@ public:
 
     virtual void 			SetCacheSize(int forwardCache, int backwardCache = 0);
     virtual void 			MultiplyZoom(float factor);
-    
+
     virtual	void 			WriteOutline(BOutlineListView* list);
-    
+
     virtual	void			FindString(BString const& name, BLooper* looper, BHandler* handler,
     							int32 flag = 0);
-    							
+
    			bool			HighlightUnderText(void);
-    
+
 	bool					fStopThread;
-	
+
 protected:
     virtual std::pair<BBitmap*, bool> 	_RenderBitmap(int const& pageNumber) = 0;
     virtual std::tuple< std::vector<BString>, std::vector<BRect> >
     									_FindString(BString const& name, int const& page);
-    
-    
+
+
 	static void* 						_DrawingThread(void* arg);
-	
+
 	pthread_t	                            	fDrawingThread;
-	
+
 	static pthread_mutex_t						gEngineStopMutex;
-	
-    
+
+
     float                           			fZoomFactor;
     int                             			fPages;
     int                             			fRotation;
     int                             			fForwardCache;
     int                             			fBackwardCache;
     int                             			fCurrentPageNo;
-    
+
     int32										fSearchFlag;
 
     std::vector<std::pair< BBitmap*, bool> >	fBitmap;
     std::vector<pthread_mutex_t>            	fMutex;
-    
+
     BRect										fDefaultRect;
     bool										fHighlightUnderText;
-    
+
 	Debug										out;
-	
+
 private:
     static void* 						_TextSearchThread(void* arg);
-    
+
     pthread_t	                        fTextSearchThread;
-   
+
     bool								fStopTextSearchThread;
-    
+
     static pthread_mutex_t				gTextSearchStopMutex;
-    
+
     BLooper*							fTargetLooper;
     BHandler*							fSearchHandler;
-    
+
     BString								fSearchString;
 };
 

--- a/application/DJVUEngine.cpp
+++ b/application/DJVUEngine.cpp
@@ -34,8 +34,8 @@ DJVUEngine::DJVUEngine(BString fileName, BString& password)
 	while (!ddjvu_document_decoding_done(fDocument))
 		_HandleDjvuMessages(fContext, true);
 
-    if (ddjvu_document_decoding_error(fDocument))
-        throw;
+	if (ddjvu_document_decoding_error(fDocument))
+		throw;
 
 	Start();
 }

--- a/application/DJVUEngine.cpp
+++ b/application/DJVUEngine.cpp
@@ -403,5 +403,5 @@ DJVUEngine::_FindString(BString const& name, int const& page)
 		}
 	}
 
-    return move(make_tuple(contextVec, rectVec));
+    return make_tuple(contextVec, rectVec);
 }

--- a/application/DJVUEngine.cpp
+++ b/application/DJVUEngine.cpp
@@ -359,7 +359,7 @@ DJVUEngine::_FindString(BString const& name, int const& page)
 
 	bool foundMatch = false;
 
-	for (int i = 0; i < textVec.size(); ++i) {
+	for (uint32 i = 0; i < textVec.size(); ++i) {
 		foundMatch = false;
 
 		if (needMatchCase) {
@@ -387,12 +387,12 @@ DJVUEngine::_FindString(BString const& name, int const& page)
 			if (from < 0)
 				from = 0;
 
-			int to	 = i + deltaIndexRight;
+			uint32 to	 = i + deltaIndexRight;
 			if (to >= textVec.size())
 				to = textVec.size() - 1;
 
 			BString str;
-			for (int j = from; j < to; ++j) {
+			for (uint32 j = from; j < to; ++j) {
 				str += textVec[j];
 				str += " ";
 			}

--- a/application/DJVUEngine.cpp
+++ b/application/DJVUEngine.cpp
@@ -139,7 +139,7 @@ DJVUEngine::FileName(void) const
 
 unique_ptr<BBitmap>
 DJVUEngine::RenderBitmap(int const& pageNumber,
-	int const& width, int const& height, int const& rotation)
+	uint32 const& width, uint32 const& height, int const& rotation)
 {
 	if (pageNumber < 0 || pageNumber >= fPages) {
     	return unique_ptr<BBitmap>(nullptr);

--- a/application/DJVUEngine.h
+++ b/application/DJVUEngine.h
@@ -30,27 +30,27 @@ public:
     int						PageCount(void) const;
 
     virtual BString         GetProperty(BString name);
-                                
+
  	virtual	void			WriteOutline(BOutlineListView* list);
 
- 	virtual std::unique_ptr<BBitmap> 	RenderBitmap(int const& pageNumber,int const& width,
-    										int const& height, int const& rotation = 0);
- 
+ 	virtual std::unique_ptr<BBitmap> 	RenderBitmap(int const& pageNumber,uint32 const& width,
+    										uint32 const& height, int const& rotation = 0);
+
 private:
     virtual std::pair<BBitmap*, bool>   _RenderBitmap(int const& pageNumber);
-    
+
     virtual std::tuple< std::vector<BString>, std::vector<BRect> >
     									_FindString(BString const& name, int const& page);
-    									
+
     void								_HandleDjvuMessages(ddjvu_context_t *context,
     										int wait = false);
 
     BString                 fFileName;
     BString               	fPassword;
-    
+
     ddjvu_context_t*		fContext;
     ddjvu_document_t*		fDocument;
-    
+
     static pthread_mutex_t 	gRendermutex;
 
     Debug             		out;

--- a/application/ImageSpinner.cpp
+++ b/application/ImageSpinner.cpp
@@ -210,7 +210,7 @@ BasicImageSpinner::Draw(BRect updateRect)
     	offset.y = 0;
 
     bool hasDrawn = false;
-   	int index = 0;
+   	uint32 index = 0;
     for (auto it = fItems.begin(); it != fItems.end(); ++it, ++index) {
     	BBitmap* bitmap = (BBitmap*)(&*get<0>(*it));
     	auto rect = bitmap->Bounds().OffsetByCopy(offset);
@@ -427,7 +427,7 @@ BasicImageSpinner::MoveLeftSelectedItem(void)
 
 
 	auto it = fItems.begin();
-	for (int i = 1; i < fCurrentIndex; ++i)
+	for (uint32 i = 1; i < fCurrentIndex; ++i)
 		++it;
 
 	auto left = it;
@@ -446,7 +446,7 @@ BasicImageSpinner::MoveRightSelectedItem(void)
 
 	float width = fSpace;
 	auto it = fItems.begin();
-	for (int i = 0; i < fCurrentIndex; ++i)
+	for (uint32 i = 0; i < fCurrentIndex; ++i)
 		++it;
 
 	auto left = it;
@@ -479,7 +479,7 @@ BasicImageSpinner::RemoveSelectedItem(void)
 		return;
 
 	auto it = fItems.begin();
-	for (int i = 0; i < fCurrentIndex; ++i)
+	for (uint32 i = 0; i < fCurrentIndex; ++i)
 		++it;
 
 	fTotalWidth -= (get<0>(*it)->Bounds().Width() + fSpace);
@@ -646,7 +646,7 @@ BasicImageSpinner::_Next(void)
 
 	float width = fSpace;
 	auto it = fItems.begin();
-	for (int i = 0; i <= fCurrentIndex; ++i, ++it)
+	for (uint32 i = 0; i <= fCurrentIndex; ++i, ++it)
 		width += get<0>(*it)->Bounds().Width() + fSpace;
 
 	if (Bounds().right < width)
@@ -667,7 +667,7 @@ BasicImageSpinner::_Back(void)
 
 	float width = 0;
 	auto it = fItems.begin();
-	for (int i = 0; i < fCurrentIndex; ++i, ++it)
+	for (uint32 i = 0; i < fCurrentIndex; ++i, ++it)
 		width += get<0>(*it)->Bounds().Width() + fSpace;
 
 	if (Bounds().left > width)

--- a/application/ImageSpinner.cpp
+++ b/application/ImageSpinner.cpp
@@ -444,7 +444,6 @@ BasicImageSpinner::MoveRightSelectedItem(void)
 		|| fItems.size() < 2)
 		return;
 
-	float width = fSpace;
 	auto it = fItems.begin();
 	for (uint32 i = 0; i < fCurrentIndex; ++i)
 		++it;

--- a/application/ImageSpinner.h
+++ b/application/ImageSpinner.h
@@ -27,7 +27,7 @@ class BasicImageSpinner : public BView
 public:
 						BasicImageSpinner(void);
 	virtual 			~BasicImageSpinner();
-	
+
 	virtual void    	AttachedToWindow(void);
 	virtual void    	Draw(BRect updateRect);
     virtual	void 	  	FrameResized(float newWidth, float newHeight);
@@ -37,17 +37,17 @@ public:
     virtual	void		MouseUp(BPoint where);
     virtual	void		MouseMoved(BPoint where, uint32 code,
                         	const BMessage* dragMessage);
-                        
+
         	void		Add(BString const& str, std::unique_ptr<BBitmap>&& bitmap);
-        	
+
         	void		Next(void);
         	void		Back(void);
-        	
+
         	bool		NeedsFile(BString const& filePath);
-        	
+
         	void		RemoveBackItem(void);
 			void		RemoveSelectedItem(void);
-			
+
 			void		MoveLeftSelectedItem(void);
 			void		MoveRightSelectedItem(void);
 
@@ -65,24 +65,24 @@ private:
 			void		_Select(BPoint const& pos);
 			void		_SelectIndex(int const& index);
 			void		_ScrollToSelection(void);
-			
+
 			BString		_RandomName(void);
-			
-	
+
+
 	std::list< std::tuple<std::unique_ptr<BBitmap>, BString, int> >		fItems;
-	
+
 	BPoint						fOldMousePos;
 	uint32	            		fMouseButtons;
-	
+
 	float						fSpace;
 	float						fTotalWidth;
 	bool						fIsPanning;
-	int							fMaxItemsNumber;
-	int							fCurrentIndex;
+	uint32						fMaxItemsNumber;
+	uint32						fCurrentIndex;
 	BString						fAppName;
 	BString						fSettingsPath;
-	
-		
+
+
 	Debug						out;
 };
 
@@ -93,31 +93,31 @@ public:
 	virtual void    MakeFocus(bool focus);
 	virtual void    MessageReceived(BMessage* message);
 	virtual void    AttachedToWindow(void);
-					
+
 			void	Add(BString const& filePath, std::unique_ptr<BBitmap>&& bitmap);
-			
+
 			bool	NeedsFile(BString const& filePath);
-			
+
 			float	PreferredImageHeight(void);
-										
+
 private:
 
 	ImageButton*		fDeleteButton;
 	ImageButton*		fBackButton;
 	ImageButton*		fNextButton;
 	ImageButton*		fOpenButton;
-	
-	
+
+
 	BasicImageSpinner*	fBasicImageSpinner;
-	
+
 	float				fImageHeight;
-	
+
 	enum {
-		M_BACK = 'ib01', M_NEXT = 'in01', 
+		M_BACK = 'ib01', M_NEXT = 'in01',
 		M_MOVE_LEFT = 'im01', M_MOVE_RIGHT = 'im02',
-		M_DELETE = 'id01'	
+		M_DELETE = 'id01'
 	};
-	
+
 };
 
 #endif // IMAGESPINNER_H

--- a/application/OutlineView.cpp
+++ b/application/OutlineView.cpp
@@ -285,6 +285,10 @@ OutlineListView::Invoke(BMessage* message)
 		_GoToPage(item->PageNumber());
 
 	BListView::Invoke(message);
+
+	// added this return call to silence -Wreturn-type warning
+	// should probably be replaced by real error handling
+	return B_OK;
 }
 
 

--- a/application/PDFEngine.cpp
+++ b/application/PDFEngine.cpp
@@ -248,7 +248,7 @@ PDFEngine::_FindString(BString const& name, int const& pageNumber)
 		fz_rethrow(fContext);
 	}
 
-	return move(make_tuple(contextVec, rectVec));
+	return make_tuple(contextVec, rectVec);
 }
 
 

--- a/application/PDFEngine.cpp
+++ b/application/PDFEngine.cpp
@@ -270,7 +270,7 @@ PDFEngine::FileName(void) const
 
 unique_ptr<BBitmap>
 PDFEngine::RenderBitmap(int const& pageNumber,
-	int const& width, int const& height, int const& rotation)
+	uint32 const& width, uint32 const& height, int const& rotation)
 {
 	if (pageNumber < 0 || pageNumber >= fPages) {
 		return unique_ptr<BBitmap>(nullptr);
@@ -342,7 +342,7 @@ PDFEngine::RenderBitmap(int const& pageNumber,
 			fz_run_display_list(fRenderContext, list, dev, ctm, bounds, nullptr);
    		 else
 			fz_run_page(fRenderContext, page, dev, ctm, nullptr);
-			
+
 		fz_close_device(fRenderContext, dev);
 		fz_drop_device(fRenderContext, dev);
 		dev = nullptr;
@@ -368,7 +368,7 @@ PDFEngine::RenderBitmap(int const& pageNumber,
 	BBitmap* bitmap = new BBitmap(BRect(0, 0, imageWidth - 1, imageHeight - 1), B_RGBA32);
 	bitmap->SetBits(fz_pixmap_samples(fRenderContext, image),
 		imageWidth * imageHeight * fz_pixmap_components(fRenderContext, image), 0, B_RGBA32);
-	
+
 	fz_close_device(fRenderContext, dev);
 	fz_drop_device(fRenderContext, dev);
 	fz_drop_pixmap(fRenderContext, image);

--- a/application/PDFEngine.h
+++ b/application/PDFEngine.h
@@ -33,11 +33,11 @@ public:
     int						PageCount(void) const;
 
     virtual BString         GetProperty(BString name);
-                                
+
  	virtual	void			WriteOutline(BOutlineListView* list);
- 	
- 	virtual std::unique_ptr<BBitmap> RenderBitmap(int const& pageNumber,int const& width,
-    										int const& height, int const& rotation = 0);
+
+ 	virtual std::unique_ptr<BBitmap> RenderBitmap(int const& pageNumber,uint32 const& width,
+    										uint32 const& height, int const& rotation = 0);
 
 private:
     virtual std::pair<BBitmap*, bool>   _RenderBitmap(int const& pageNumber);
@@ -47,16 +47,16 @@ private:
     fz_document*			fDocument;
     fz_context*				fContext;
 	fz_context*				fRenderContext;
-    
+
     fz_page*				fPage;
 	fz_display_list*		fList;
 	fz_device*				fDev;
-    
+
     fz_colorspace*			fColorSpace;
 
     BString                 fFileName;
     BString               	fPassword;
-    
+
 	pthread_mutex_t			fRendermutex = PTHREAD_MUTEX_INITIALIZER;
 
     Debug             		out;

--- a/application/Tools.h
+++ b/application/Tools.h
@@ -35,64 +35,64 @@ public:
 	{
 	    app_info	info;
 	    be_app->GetAppInfo(&info);
-	
+
 	    BPath path = BPath(&info.ref);
 	    path.GetParent(&path);
-	
+
 	    return path.Path();
 	}
-	
-	
+
+
 	static BString
 	AppName(void)
 	{
 	    app_info	info;
 	    be_app->GetAppInfo(&info);
-	
+
 	    BPath path = BPath(&info.ref);
 	    path.GetParent(&path);
-	
+
 	    return path.Leaf();
 	}
-	
-	
+
+
 	static BString
 	SettingsPath(void)
 	{
 		BPath path;
 	    if (find_directory(B_USER_SETTINGS_DIRECTORY, &path) != B_OK)
 	        return "";
-	
+
 	    path.Append(AppName().Capitalize());
 	    create_directory(path.Path(), 0755);
-	    
+
 	    BString str(path.Path());
 	    str.Append("/");
-	    return str;	
+	    return str;
 	}
-	
-	
+
+
 	static std::vector<BString>
 	Split(BString str, const char token, BString start = "", BString stop = "")
 	{
 	    std::vector<BString> vec;
-	
+
 	    int n1 = 0;
 	    int n2 = str.Length();
-	
+
 	    if (start != "")
 	        n1 = str.FindFirst(start, 0);
-	
+
 	    if (stop != "")
 	        n2 = str.FindFirst(stop, n1 + 1);
-	
+
 	    if (n1 == B_ERROR || n2 == B_ERROR)
 	        return vec;
-	
+
 	    n1 = n1 + start.Length();
-	
+
 	    int n = n1;
-	
+
 	    for (; n < n2; ++n)
 	        if (str[n] == token) {
 	            if (n > 0 && str[n-1] != token) {
@@ -105,39 +105,39 @@ public:
 	                n1 = n + 1;
 	            }
 	        }
-	
+
 	    char temp[n - n1 + 1] ;
 	    str.CopyInto(temp, n1, n - n1);
 	    temp[n - n1] = '\0';
 	    vec.push_back(temp);
 	    return vec;
 	}
-	
-	
+
+
 	static std::vector<BString>
 	Split(unsigned int length, BString str,
 	    const char token, BString start, BString stop)
 	{
 	    std::vector<BString> vec;
-	
+
 	    int n1 = 0;
 	    int n2 = str.Length();
-	
+
 	    if (start != "")
 	        n1 = str.FindFirst(start, 0);
-	
+
 	    if (stop != "")
 	        n2 = str.FindFirst(stop, n1 + 1);
-	
+
 	    if (n1 == B_ERROR || n2 == B_ERROR) {
 	        vec.resize(length, "");
 	        return vec;
 	    }
-	
+
 	    n1 = n1 + start.Length();
-	
+
 	    int n = n1;
-	
+
 	    for (; n < n2; ++n)
 	        if (str[n] == token) {
 	            if (n > 0 && str[n-1] != token) {
@@ -147,60 +147,60 @@ public:
 	                vec.push_back(temp);
 	                if (vec.size() == length)
 	                    return vec;
-	
+
 	                n1 = n + 1;
 	            } else {
 	                n1 = n + 1;
 	            }
 	        }
-	
+
 	    char temp[n - n1 + 1] ;
 	    str.CopyInto(temp, n1, n - n1);
 	    temp[n - n1] = '\0';
 	    vec.push_back(temp);
 	    vec.resize(length, "");
-	
+
 	    return vec;
 	}
-	
-	
+
+
 	static BString
 	Find(BString str, BString searchStr)
 	{
 	   BString result = "";
-	
+
 	  if (str.Length() == 0 || searchStr.Length() == 0)
 	    return result;
-	
+
 	  int n1 = str.FindFirst(searchStr) + searchStr.Length();
 	  int n2 = str.FindFirst(" ", n1);
-	
+
 	  if (n2 == B_ERROR)
 		n2 = str.Length();
-	
+
 	  str.CopyInto(result, n1, n2 - n1);
-	
+
 	  return result;
 	}
-	
-	
+
+
 	static BBitmap*
 	LoadBitmap(BString const& imageName, int size)
 	{
 	    BResources* res = be_app->AppResources();
-	
+
 		if (res == nullptr)
 			return nullptr;
-	
+
 		size_t nbytes = 0;
 		color_space cspace = B_RGBA32;
-	
+
 		const void* data = res->LoadResource('HVIF', imageName.String(), &nbytes);
-	
+
 	   // size--;
-	
+
 		BBitmap* bitmap = new BBitmap(BRect(0, 0, size, size), cspace);
-	
+
 		if (bitmap->InitCheck() != B_OK) {
 	        delete bitmap;
 	        bitmap = nullptr;
@@ -209,12 +209,12 @@ public:
 	        delete bitmap;
 	        bitmap = nullptr;
 	    }
-	
+
 	    res->RemoveResource(data);
 		return bitmap;
 	}
-	
-	
+
+
 	static void
 	ExportBitmap(BBitmap* bitmap,
 		BString const& path, int32 const& format = B_PNG_FORMAT)
@@ -225,64 +225,64 @@ public:
     	roster->Translate(&stream, NULL, NULL, &imageFile, B_PNG_FORMAT);
     	BBitmap* bmp;
     	stream.DetachBitmap(&bmp);
-    		
+
 	}
-	
+
 
 	static std::unique_ptr<BBitmap>
 	RescaleBitmap(std::unique_ptr<BBitmap> src, int32 width, int32 height)
 	{
 		if (src == nullptr || src->IsValid() == false)
 			throw "Tools::RescaleBitmap";
-			
+
 		if (height <= 0) {
 			if (width <= 0)
 				return src;
-		
-			height = (width * src->Bounds().Height()) / src->Bounds().Width();		
+
+			height = (width * src->Bounds().Height()) / src->Bounds().Width();
 		} else if (width <= 0) {
 			if (height <= 0)
 				return src;
-			
+
 			width = (height * src->Bounds().Width()) / src->Bounds().Height();
 		}
-	
+
 		BRect srcSize = src->Bounds();
-		
+
 		if (height < 0) {
 			float srcProp = srcSize.Height()/srcSize.Width();
 			height = (int32)(width * ceil(srcProp));
 		}
-		
+
 		BBitmap* res = new BBitmap(BRect(0, 0, (float)width, (float)height),
 	        src->ColorSpace());
-	
+
 		float dx = (srcSize.Width() + 1)/(float)(width + 1);
 		float dy = (srcSize.Height() + 1)/(float)(height + 1);
 		uint8 bpp = (uint8)(src->BytesPerRow()/ceil(srcSize.Width()));
-	
+
 		int srcYOff = src->BytesPerRow();
 		int dstYOff = res->BytesPerRow();
-	
+
 		void* dstData = res->Bits();
 		void* srcData = src->Bits();
-	
+
 		for (int32 y = 0; y <= height; y++) {
 			void* dstRow = (void*)((uintptr_t)dstData + (uintptr_t)(y * dstYOff));
 			void* srcRow = (void*)((uintptr_t)srcData + ((uintptr_t)(y * dy) * srcYOff));
-	
+
 			for (int32 x = 0; x <= width; x++)
 				memcpy((void*)((uintptr_t)dstRow + (x * bpp)), (void*)((uintptr_t)srcRow
 	                                              + ((uintptr_t)(x * dx) * bpp)), bpp);
 		}
-		
-		std::unique_ptr<BBitmap> bitmap(res);
-		return move(bitmap);
-	}	
 
-	
+		std::unique_ptr<BBitmap> bitmap(res);
+		return bitmap;
+	}
+
+
 private:
-			Tools(void);	
+			Tools(void);
 };
 
 #endif


### PR DESCRIPTION
This PR fixes several warnings (-Wreorder, -Wsign-compare, -Wmisleading-indentation, Wunused-variable, -Wreturn-type, -Wnarrowing and -Wpessimizing-move) that occured during compilation. No functional changes. 
